### PR TITLE
[VIVO-1483] Use 5.1.46 mysql-connector-java dependency; match Vitro connection URL handling

### DIFF
--- a/jena2tools/pom.xml
+++ b/jena2tools/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>jena2tools</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>jenatools</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.11</version>
+            <version>5.1.46</version>
         </dependency>
     </dependencies>
 </project>

--- a/jena2tools/src/main/java/org/vivoweb/tools/ApplicationStores.java
+++ b/jena2tools/src/main/java/org/vivoweb/tools/ApplicationStores.java
@@ -531,7 +531,7 @@ public class ApplicationStores {
         }
     }
 
-    static final String DEFAULT_DRIVER_CLASS = "com.mysql.cj.jdbc.Driver";
+    static final String DEFAULT_DRIVER_CLASS = "com.mysql.jdbc.Driver";
     static final String DEFAULT_LAYOUT = "layout2/hash";
     static final String DEFAULT_TYPE = "MySQL";
 

--- a/jena3tools/pom.xml
+++ b/jena3tools/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>jena3tools</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>jenatools</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.11</version>
+            <version>5.1.46</version>
         </dependency>
     </dependencies>
 </project>

--- a/jena3tools/src/main/java/org/vivoweb/tools/ApplicationStores.java
+++ b/jena3tools/src/main/java/org/vivoweb/tools/ApplicationStores.java
@@ -504,7 +504,7 @@ public class ApplicationStores {
         }
     }
 
-    static final String DEFAULT_DRIVER_CLASS = "com.mysql.cj.jdbc.Driver";
+    static final String DEFAULT_DRIVER_CLASS = "com.mysql.jdbc.Driver";
     static final String DEFAULT_LAYOUT = "layout2/hash";
     static final String DEFAULT_TYPE = "MySQL";
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>jenatools</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>pom</packaging>
 
     <name>Vitro</name>


### PR DESCRIPTION
[JIRA VIVO 1483](https://jira.duraspace.org/browse/VIVO-1483)

This updates the mysql-connector-java dependency to the ~~latest (8.0.11)~~ 5.1.46 and brings it in line with Vitro assuming [pull request 69](https://github.com/vivo-project/Vitro/pull/69) is merged. Tested both jena2tools and jena3tools working, ~~though the updated connector throws a couple warnings.~~

`$ java -jar jena2tools-1.1.1.jar -d /usr/local/vivodev/home -e  `

`Loading class 'com.mysql.jdbc.Driver'. This is deprecated. The new driver class is 'com.mysql.cj.jdbc.Driver'. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary.`

`Fri Apr 27 14:36:28 MDT 2018 WARN: Establishing SSL connection without server's identity verification is not recommended. According to MySQL 5.5.45+, 5.6.26+ and 5.7.6+ requirements SSL connection must be established by default if explicit option isn't set. For compliance with existing applications not using SSL the verifyServerCertificate property is set to 'false'. You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification. `

`Writing Configuration
Writing Content
Export complete`
(Note: warnings described were from 8.0.11, we are reverting to 5.1.46 which is the latest in the 5 version line).