### PR TITLE
Support new location for runtime.properties

### DIFF
--- a/jena3tools/src/main/java/org/vivoweb/tools/ApplicationStores.java
+++ b/jena3tools/src/main/java/org/vivoweb/tools/ApplicationStores.java
@@ -65,6 +65,10 @@ public class ApplicationStores {
     public ApplicationStores(String homeDir, RDFFormat outputFormat) {
 
         File config = Utils.resolveFile(homeDir, "config/applicationSetup.n3");
+        File runtimeProperties = Utils.resolveFile(homeDir, "config/runtime.properties");
+        if (!runtimeProperties.exists()) {
+            runtimeProperties = Utils.resolveFile(homeDir, "runtime.properties");
+        }
 
         this.outputFormat = outputFormat;
 
@@ -88,7 +92,7 @@ public class ApplicationStores {
                     isType(contentSource, "java:edu.cornell.mannlib.vitro.webapp#triplesource.impl.sdb.ContentTripleSourceSDB")) {
                 Properties props = new Properties();
                 try {
-                    InputStream in = new FileInputStream(Utils.resolveFile(homeDir, "runtime.properties"));
+                    InputStream in = new FileInputStream(runtimeProperties);
                     props.load(in);
                     in.close();
                 } catch (FileNotFoundException f) {
@@ -505,7 +509,7 @@ public class ApplicationStores {
                     }
                 }
             }
-            
+
             return DriverManager.getConnection(url, user, pass);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException("Unable to find database driver");

--- a/jena3tools/src/main/java/org/vivoweb/tools/JenaCli.java
+++ b/jena3tools/src/main/java/org/vivoweb/tools/JenaCli.java
@@ -159,6 +159,10 @@ public class JenaCli {
                     if ("applicationSetup.n3".equals(configs.getName())) {
                         hasConfigDir = true;
                     }
+
+                    if ("runtime.properties".equals(child.getName())) {
+                        hasRuntimeProperties = true;
+                    }
                 }
 
             }

--- a/jena3tools/src/main/java/org/vivoweb/tools/JenaCli.java
+++ b/jena3tools/src/main/java/org/vivoweb/tools/JenaCli.java
@@ -160,7 +160,7 @@ public class JenaCli {
                         hasConfigDir = true;
                     }
 
-                    if ("runtime.properties".equals(child.getName())) {
+                    if ("runtime.properties".equals(configs.getName())) {
                         hasRuntimeProperties = true;
                     }
                 }


### PR DESCRIPTION
According to the [Documentation](https://wiki.duraspace.org/display/VIVODOC110x/Upgrading+VIVO#UpgradingVIVO-Changestoruntime.properties), the location for `runtime.properties` moved from vivo-home to vivo-home/config.

This change adds support for the new location for jena3tools while maintaining support for the old location. The new location has preference, so it will be used when runtime.properties exists in both locations.