### PR TITLE
[VIVO-1732] - Bugfix for exporting from TDB databases in jena3tools

### DIFF
--- a/jena3tools/src/main/java/org/vivoweb/tools/ApplicationStores.java
+++ b/jena3tools/src/main/java/org/vivoweb/tools/ApplicationStores.java
@@ -241,22 +241,26 @@ public class ApplicationStores {
             try {
                 OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(output, false));
                 try {
-                    if (LayoutType.LayoutTripleNodesHash.equals(contentStoreDesc.getLayout()) ||
-                        LayoutType.LayoutTripleNodesIndex.equals(contentStoreDesc.getLayout())) {
-                        if (DatabaseType.MySQL.equals(contentStoreDesc.getDbType()) ||
-                                DatabaseType.PostgreSQL.equals(contentStoreDesc.getDbType())) {
+                    if (contentConnection != null) {
+                        if (LayoutType.LayoutTripleNodesHash.equals(contentStoreDesc.getLayout()) ||
+                            LayoutType.LayoutTripleNodesIndex.equals(contentStoreDesc.getLayout())) {
+                            if (DatabaseType.MySQL.equals(contentStoreDesc.getDbType()) ||
+                                    DatabaseType.PostgreSQL.equals(contentStoreDesc.getDbType())) {
 
-                            long offset = 0;
-                            long limit  = 10000;
+                                long offset = 0;
+                                long limit  = 10000;
 
-                            Dataset blankQuads = DatasetFactory.create();
+                                Dataset blankQuads = DatasetFactory.create();
 
-                            while (writeContentSQL(outputStream, blankQuads, offset, limit)) {
-                                offset += limit;
-                            }
+                                while (writeContentSQL(outputStream, blankQuads, offset, limit)) {
+                                    offset += limit;
+                                }
 
-                            if (blankQuads.asDatasetGraph().size() > 0) {
-                                writeRDF(outputStream, blankQuads, outputFormat);
+                                if (blankQuads.asDatasetGraph().size() > 0) {
+                                    writeRDF(outputStream, blankQuads, outputFormat);
+                                }
+                            } else {
+                                writeRDF(outputStream, contentDataset, outputFormat);
                             }
                         } else {
                             writeRDF(outputStream, contentDataset, outputFormat);


### PR DESCRIPTION


**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1732)**: jena3tools does not work with TDB databases	

# What does this pull request do?
Fixes a bug that prevented jena3tools from exporting content from TDB databases

# What's new?
Bug fix only. Skips logic that reads SDB database layout type if the database is determined to not be an SDB database and attempts to export immediately. 

# How should this be tested?
Attempt to export from a TDB database using jena3tools
`java -jar jena3tools -e -d /usr/local/vivo/home`

Confirm that the content export fails.
Build with changes in this pull request. `mvn package`
Repeat export with changes.
`java -jar jena3tools/target/jena3tools-1.3.0-SNAPSHOT.jar -e -d /usr/local/vivo/home`

Confirm export completes.

# Additional notes
I expect a similar problem exists for jena2tools, but I don't have a Jena 2 TDB database to test against.

# Interested parties
@VIVO-project/vivo-committers
